### PR TITLE
fixed syntax:  key start marker for mainz2 was corrupted

### DIFF
--- a/hosts/mainz2
+++ b/hosts/mainz2
@@ -1,6 +1,6 @@
 Address = ic-mainz2.freifunk-mainz.de
 Port = 10655
-----BEGIN RSA PUBLIC KEY-----
+-----BEGIN RSA PUBLIC KEY-----
 MIIBCgKCAQEA4etejQVw/F3c5TlL8vHuO0dxdyPem+8yV6VUu++uexbGpwB6mMQV
 RDImqz9KM6AND5wSH2kcO9qmY+q5Tg7VmGvITYvVZWwaSihqKVcCj2lgQUUrn2IO
 /S9vaeiITp19BEfVMkXHSzlfi4sa7QhPFKe8jpua4qnWbXaOFV9DusLzLZUhAboQ


### PR DESCRIPTION
Sorry!
Introduced a tiny syntax error in latest commit - one missing "-" fixed now
