### PR TITLE
post-merge: Use absolute path for invoke-rc.d.

### DIFF
--- a/scripts/post-merge
+++ b/scripts/post-merge
@@ -25,6 +25,6 @@ for HOST in hosts/*; do
   echo "ConnectTo = ${HOST##*/}" >> $TINCCFG
 done
 
-invoke-rc.d tinc reload icvpn
+/usr/sbin/invoke-rc.d tinc reload icvpn
 
 exit 0


### PR DESCRIPTION
When the hook is triggered due to an cron job, the path may
not contain "/usr/sbin/" and thus the daemon reload is not happening.