### PR TITLE
Readded augsburg 1. Seems to be back

### DIFF
--- a/hosts/augsburg1
+++ b/hosts/augsburg1
@@ -1,0 +1,6 @@
+Address = augsburg1.icvpn.augsburg.freifunk.net
+-----BEGIN RSA PUBLIC KEY-----
+MIGJAoGBALVQaY0axASCewZdfMPbxUBwphhoDHKzm0SvpietNy0gy+43Jb+N/Cs+
+d9l9HlAS2ngrCAahVm/GRA3iYHH2i5JdZnzxPFKdkefcZFz7x0ZDaqeqpb2YLWFs
+z2LPm37OCcsi9NPZtvDG+0Nas370xDn/6uZhCd0gAplDuI+3m0vRAgMBAAE=
+-----END RSA PUBLIC KEY-----


### PR DESCRIPTION
Tinc log says:
```
Cannot open config file /usr/local/etc/tinc/icvpn/hosts/augsburg1: No such file or directory
Cannot open config file /usr/local/etc/tinc/icvpn/hosts/augsburg1: No such file or directory
Cannot open config file /usr/local/etc/tinc/icvpn/hosts/augsburg1: No such file or directory
Invalid size 90 for public key!
Got bad ANS_PUBKEY from augsburg1 (s1.coffee-it.de port tinc): invalid pubkey
```