### PR TITLE
FFNord - VPN1 hinzugefügt

### DIFF
--- a/hosts/nordgw1
+++ b/hosts/nordgw1
@@ -1,0 +1,11 @@
+Address = vpn1.ffnord.net
+Port = 656
+
+-----BEGIN RSA PUBLIC KEY-----
+MIIBCgKCAQEAvaUgdjGpBdiRW1uBlfsti4PyjqQNdwFu//8DMyzup6XfmuS/4Byc
+zJTVQFNwzj8qPnCtYkAVkBaeAOHM5e3S+ON2Ir9O5LEmzKDXzqjhDBgx1Z6CWzny
+6cfNOGjmjldXdfmAYjsJvJwZoRFb3ENe3/mhTWls8r2ToVQpriDWvJ/vw3Ewiq4R
+mnbHTat7zkJi61bVz8ck/C5kx7hta0RXvLLhmZtjFLgI0GTC6z/JFInWdjE56PZb
+/BpJzmyhVM4OUHlsytuMz/XEhCzRkrQWpnd8YeHCmUzBPIyWx04ItUyVZDuPFxmV
+OxK3hRjGajxQeibTNXVGSDSbpLZtccLHCQIDAQAB
+-----END RSA PUBLIC KEY-----


### PR DESCRIPTION
In kürze hält VPN1 Einzug ins FFNord Netz. Dies dient der Anbildung an das ICVPN.

CC: @rubo77 @sventhomsen