### PR TITLE
scripts/post-merge: Use conf.d directory instead of tinc.conf

### DIFF
--- a/scripts/post-merge
+++ b/scripts/post-merge
@@ -15,17 +15,20 @@ fail() {
 }
 
 BASE=$(git rev-parse --show-toplevel)
-TINCCFG=$BASE/tinc.conf
-test -w $TINCCFG || fail "ERR: $TINCCFG is not writeable"
+TINCCFG=$BASE/conf.d/connects.conf
 
-sed -i '/^ConnectTo/d' $TINCCFG
+test -d $(dirname $TINCCFG) || mkdir $(dirname $TINCCFG)
+
+if ! test -d $(dirname $TINCCFG) || ! ( test -w $TINCCFG || test -w $(dirname $TINCCFG) ); then
+  fail "ERR: $TINCCFG is not writeable"
+fi
 
 while read HOST; do
   # skip hosts without address
   grep -iq '^Address' -- hosts/"$HOST" || continue
 
-  echo "ConnectTo = $HOST" >> $TINCCFG
-done < metanodes
+  echo "ConnectTo = $HOST"
+done < metanodes > $TINCCFG
 
 if hash tinc 2>/dev/null; then
     # prefer the command line interface that comes with tinc1.1 if it exists


### PR DESCRIPTION
This allows the main configuration file to be 100% self-defined and remain unchanged by the cronjob. It can thus be included in any versioning that may be done of system configuration and can be managed by Ansible or whatever orchestration a community uses.